### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -160,31 +160,9 @@ http://example.com/user/admin_login.
 This would affect all campus services depending on CAS.  The 
 responsibility for fixing the problem would be on the CalNet team.
 
-Sites using UC Berkeley CAS can be toggled to use an offsite CAS cluster should 
-this scenario arise.
-
-Toggle your site to use the offsite CAS cluster:
-```
-$ drush vset ucberkeley_envconf_cas_backup_server_enabled 1
-```
-Confirm that cas_server was updated to the backup server:
-```
-$ drush vget cas_server
-cas_server: cas-p4.calnet.berkeley.edu
-```
-Try authenticating to your site.
-
-When the auth.berkeley.edu is back online, toggle your site to use this server
-again:
-```
-$ drush vset ucberkeley_envconf_cas_backup_server_enabled 0
-ucberkeley_envconf_cas_backup_server_enabled was set to "0".                                               [success]
-```
-Confirm the change:
-```
-$ drush vget cas_server
-cas_server: auth-test.berkeley.edu
-```
+The CalNet team uses healthchecks and automatic DNS failover to
+point auth.berkeley.edu to an offsite cluster when a problem is 
+detected.
 
 ## Upgrading 
 ### Upgrading to a new version of ucberkeley_cas (versions > 1.x) 


### PR DESCRIPTION
We've had DNS health checks and failover for over a year now so the manual changes to point at an offisite node should no longer be required.  Also we may, without notice, change the backend cluster node names.